### PR TITLE
[DO NOT MERGE] Skip to update the rotation if no layers available

### DIFF
--- a/hwc2/Hwc2Display.cpp
+++ b/hwc2/Hwc2Display.cpp
@@ -564,6 +564,13 @@ int Hwc2Display::checkRotation() {
 
   if(!mUioDisplay)
     return -1;
+
+  uint32_t layer_count = mLayers.size();
+  if (layer_count == 0) {
+     ALOGD("layers are empty, skip to update the rotation!\n");
+     return 0;
+  }
+
   uint32_t tr = 0;
   for (auto& layer : mLayers) {
     tr = layer.second.info().transform;


### PR DESCRIPTION
This is to avoid updating the screen rotation wrongly.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Tracked-On: OAM-101264