### PR TITLE
Add quick gralloc4 to gralloc1 handle conversion

### DIFF
--- a/common/BufferMapper.h
+++ b/common/BufferMapper.h
@@ -5,6 +5,8 @@
 #include <hardware/hwcomposer2.h>
 #include <system/graphics.h>
 
+#include "gralloc_handle.h"
+
 const int32_t GRALLOC1_FUNCTION_ADD_CALLBACK = 108;
 enum {
   GRALLOC_EVENT_ALLOCATE  = 0,
@@ -31,6 +33,10 @@ class BufferMapper {
   int lockBuffer(buffer_handle_t b, uint8_t*& data, uint32_t& s);
   int unlockBuffer(buffer_handle_t b);
   int addCallback(gralloc_cb cb, void* ctx);
+
+  void dump(buffer_handle_t b);
+  bool isGralloc1(buffer_handle_t b);
+  void gralloc4ToGralloc1(buffer_handle_t in, struct cros_gralloc_handle* out);
 
  private:
   BufferMapper();

--- a/common/gralloc_handle.h
+++ b/common/gralloc_handle.h
@@ -1,0 +1,99 @@
+#ifndef _GRALLOC_HANDLE_H_
+#define _GRALLOC_HANDLE_H_
+
+#include <cstdint>
+#include <cutils/native_handle.h>
+
+#define DRV_MAX_PLANES 4
+#define DRV_MAX_FDS (DRV_MAX_PLANES + 1)
+
+struct cros_gralloc4_handle {
+	native_handle_t base;
+	/*
+	 * File descriptors must immediately follow the native_handle_t base and used file
+	 * descriptors must be packed at the beginning of this array to work with
+	 * native_handle_clone().
+	 *
+	 * This field contains 'num_planes' plane file descriptors followed by an optional metadata
+	 * reserved region file descriptor if 'reserved_region_size' is greater than zero.
+	 */
+	int32_t fds[DRV_MAX_FDS];
+	uint32_t strides[DRV_MAX_PLANES];
+	uint32_t offsets[DRV_MAX_PLANES];
+	uint32_t sizes[DRV_MAX_PLANES];
+	bool from_kms;
+	uint32_t id;
+	uint32_t width;
+	uint32_t height;
+	uint32_t format; /* DRM format */
+	uint64_t format_modifier;
+	uint64_t use_flags; /* Buffer creation flags */
+	uint32_t magic;
+	uint32_t pixel_stride;
+	int32_t droid_format;
+	int32_t usage; /* Android usage. */
+	uint32_t num_planes;
+	uint64_t reserved_region_size;
+	uint64_t total_size; /* Total allocation size */
+	/*
+	 * Name is a null terminated char array located at handle->base.data[handle->name_offset].
+	 */
+	uint32_t name_offset;
+	uint32_t consumer_usage;
+	uint32_t producer_usage;
+	uint32_t yuv_color_range;   // YUV Color range.
+	uint32_t is_updated;        // frame updated flag
+	uint32_t is_encoded;        // frame encoded flag
+	uint32_t is_encrypted;
+	uint32_t is_key_frame;
+	uint32_t is_interlaced;
+	uint32_t is_mmc_capable;
+	uint32_t compression_mode;
+	uint32_t compression_hint;
+	uint32_t codec;
+	uint32_t tiling_mode;
+	uint32_t format_modifiers[2 * DRV_MAX_PLANES];
+} __attribute__((packed));
+
+typedef const struct cros_gralloc4_handle *cros_gralloc4_handle_t;
+
+/*
+ * Only use 32-bit integers in the handle. This guarantees that the handle is
+ * densely packed (i.e, the compiler does not insert any padding).
+ */
+
+struct cros_gralloc_handle {
+	native_handle_t base;
+	int32_t fds[DRV_MAX_PLANES];
+	uint32_t strides[DRV_MAX_PLANES];
+	uint32_t offsets[DRV_MAX_PLANES];
+	uint32_t sizes[DRV_MAX_PLANES];
+	uint32_t format_modifiers[2 * DRV_MAX_PLANES];
+	uint32_t width;
+	uint32_t height;
+	uint32_t format;       /* DRM format */
+	uint32_t tiling_mode;
+	uint32_t use_flags[2]; /* Buffer creation flags */
+	uint32_t magic;
+	uint32_t pixel_stride;
+	int32_t droid_format;
+	int32_t usage; /* Android usage. */
+	uint32_t consumer_usage;
+	uint32_t producer_usage;
+	uint32_t yuv_color_range;   // YUV Color range.
+	uint32_t is_updated;        // frame updated flag
+	uint32_t is_encoded;        // frame encoded flag
+	uint32_t is_encrypted;
+	uint32_t is_key_frame;
+	uint32_t is_interlaced;
+	uint32_t is_mmc_capable;
+	uint32_t compression_mode;
+	uint32_t compression_hint;
+	uint32_t codec;
+	uint32_t aligned_width;
+	uint32_t aligned_height;
+} __attribute__((packed));
+
+typedef const struct cros_gralloc_handle *cros_gralloc_handle_t;
+
+#endif

--- a/renderer/FastBufferDump.cpp
+++ b/renderer/FastBufferDump.cpp
@@ -3,6 +3,7 @@
 #include <cutils/log.h>
 
 #include "FastBufferDump.h"
+#include "BufferMapper.h"
 
 //#define DEBUG_GL
 
@@ -153,7 +154,6 @@ int FastBufferDump::dumpToPng(const char* path, const ImageData* image) {
 int FastBufferDump::run() {
     if (!mEnableDump)
         return -1;
-
     BufferTexture bufTex(mHandle, true);
     uint32_t w = bufTex.getWidth();
     uint32_t h = bufTex.getHeight();


### PR DESCRIPTION
Temp solution for gralloc4 to gralloc1 conversion. In future, we should use gralloc4 mapper to get the common metadata needed by client.