### PR TITLE
Don't bypass rotated video layer

### DIFF
--- a/hwc2/Hwc2Display.cpp
+++ b/hwc2/Hwc2Display.cpp
@@ -894,6 +894,10 @@ bool Hwc2Display::checkMultiLayerVideoBypass() {
     return false;
   }
 
+  // Rotated video is not supported
+  if (videoLayer->info().transform != 0)
+    return false;
+
   // force video bypass or video layer is the only buffer layer
   if (mForceVideoBypass || bufferLayerCount == 1) {
     mBypassLayer = videoLayer;


### PR DESCRIPTION
A rotated video layer in multi-layer has combination of rotation and letter box. It can't be handled by client APK correctly yet.

Tracked-On: OAM-108837