### PR TITLE
Camera orientation fails in Portrait mode

### DIFF
--- a/hwc2/Hwc2Display.cpp
+++ b/hwc2/Hwc2Display.cpp
@@ -952,6 +952,12 @@ bool Hwc2Display::checkFullScreenMode() {
     if (layer.info().dstFrame.right != mWidth || layer.info().dstFrame.bottom != mHeight)
       return false;
 
+    // Prioritize Auto-Rotate when both Auto-Rotate and Rotation Bypass is enabled
+    if (mEnableRotationBypass && (layer.info().transform == HAL_TRANSFORM_ROT_90 ||
+        layer.info().transform == HAL_TRANSFORM_ROT_180 ||
+        layer.info().transform == HAL_TRANSFORM_ROT_270))
+        return false;
+
     // Supported formats
     BufferMapper::getMapper().getBufferFormat(layer.buffer(), format);
     if (format == HAL_PIXEL_FORMAT_RGBA_8888 ||


### PR DESCRIPTION
When bypass_rotation is enabled and auto-rotate is on, changing camera orientation from landscape to portrait mode fails.

Whenever auto-rotate is turned on, windows manager triggers informs camera app to update display and
display gets updated. Hwc gets the updated frames
and since bypass_rotation is enabled, it performs
the rotation again on this.

Both bypass_rotation and Auto_rotation can't be
applied at the sametime and need to prioritize
one of these.

Whenever bypass_rotation is enable and auto_rotate is on, prioritize auto_rotate.

Tracked-On: OAM-108836